### PR TITLE
Remove the rubygems requires from all plugins

### DIFF
--- a/bin/check-rabbitmq-alive.rb
+++ b/bin/check-rabbitmq-alive.rb
@@ -10,7 +10,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'rest_client'

--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -10,7 +10,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'bunny'
 

--- a/bin/check-rabbitmq-cluster-health.rb
+++ b/bin/check-rabbitmq-cluster-health.rb
@@ -17,7 +17,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'rest_client'

--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -9,7 +9,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'carrot-top'
 

--- a/bin/check-rabbitmq-messages.rb
+++ b/bin/check-rabbitmq-messages.rb
@@ -8,7 +8,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'socket'
 require 'carrot-top'

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -15,7 +15,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'rest_client'

--- a/bin/check-rabbitmq-queue.rb
+++ b/bin/check-rabbitmq-queue.rb
@@ -8,7 +8,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'socket'
 require 'carrot-top'

--- a/bin/check-rabbitmq-stomp-alive.rb
+++ b/bin/check-rabbitmq-stomp-alive.rb
@@ -12,7 +12,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'stomp'
 

--- a/bin/metrics-rabbitmq-overview.rb
+++ b/bin/metrics-rabbitmq-overview.rb
@@ -33,7 +33,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
 require 'socket'
 require 'carrot-top'

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -8,7 +8,6 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
 require 'socket'
 require 'carrot-top'


### PR DESCRIPTION
This was a check for Ruby 1.8.7 when running sensu on system ruby.  The earlier removal of all hash rockets already broke Ruby 1.8.7 support so there's no need for this.