### PR TITLE
Rubocop prefers `nil?` over `== nil`

### DIFF
--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -99,7 +99,7 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
       end
 
       # we don't care about empty queues and they'll have an infinite drain time so skip them
-      next if queue['messages'] == 0 || queue['messages'] == nil
+      next if queue['messages'] == 0 || queue['messages'].nil?
 
       # handle rate of zero which is an infinite time until empty
       if queue['backing_queue_status']['avg_egress_rate'].to_f == 0


### PR DESCRIPTION
This fixes the following Rubocop offense:

```
bin/check-rabbitmq-queue-drain-time.rb:102:59: C: Prefer the use of the nil? predicate.
      next if queue['messages'] == 0 || queue['messages'] == nil
                                                          ^^
```

