### PR TITLE
check-rabbitmq-amqp-alive uses AMQP, not REST

### DIFF
--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -5,13 +5,12 @@
 # ===
 #
 # DESCRIPTION:
-# This plugin checks if RabbitMQ server is alive using the REST API
+# This plugin checks if RabbitMQ server is alive using AMQP
 #
 # PLATFORMS:
 #   Linux, BSD, Solaris
 #
 # DEPENDENCIES:
-#   RabbitMQ rabbitmq_management plugin
 #   gem: sensu-plugin
 #   gem: bunny
 #


### PR DESCRIPTION
Update the docs to reflect that we're using AMQP, not REST, to verify the server is alive.