### PR TITLE
Pin amq-protocol version

### DIFF
--- a/lib/sensu-plugins-rabbitmq/version.rb
+++ b/lib/sensu-plugins-rabbitmq/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsRabbitMQ
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 3
+    PATCH = 4
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stomp',          '1.3.4'
   s.add_runtime_dependency 'rest-client',    '1.8.0'
   s.add_runtime_dependency 'bunny',          '1.7.0'
+  s.add_runtime_dependency 'amq-protocol',   '1.9.2' # locked as bunny 1.7.0 deps breaks on runby < 2
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '0.30'


### PR DESCRIPTION
With the release of amq-protocol it requires ruby >= 2.0:
https://rubygems.org/gems/amq-protocol/versions/2.0.0

bunny 1.7.0 has a dep requirement that is satisfied amq-protocol >= 1.9.2:
https://rubygems.org/gems/bunny/versions/1.7.0

Therefore we should lock it specifically to ensure compatibility with lower versions of ruby.