### PR TITLE
Fixing 'Check failed to run: Infinity' error in metrics-rabbitmq-queue

### DIFF
--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -93,7 +93,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
       # calculate and output time till the queue is drained in drain metrics
       queue['messages'] ||= 0
       drain_time = queue['messages'] / queue['backing_queue_status']['avg_egress_rate']
-      drain_time = 0 if drain_time.nan? # 0 rate with 0 messages is 0 time to drain
+      drain_time = 0 if drain_time.nan? || drain_time.infinite? # 0 rate with 0 messages is 0 time to drain
       output([config[:scheme], queue['name'], 'drain_time'].join('.'), drain_time.to_i, timestamp)
 
       %w(messages consumers).each do |metric|


### PR DESCRIPTION
When trying to aggregate queue metrics using metrics-rabbitmq-queue.rb, I'm running into a case whereby drain_time = Infinite, and an exception is raised when ruby attempts to convert it to an integer.

```
Check failed to run: Infinity, ["/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/metrics-rabbitmq-queue.rb:96:in `to_i'", "/opt/sensu/embedded/lib/ruby
/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/metrics-rabbitmq-queue.rb:96:in `block in run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/met
rics-rabbitmq-queue.rb:88:in `each'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/metrics-rabbitmq-queue.rb:88:in `run'", "/opt/sensu/embedded/lib
/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```
This merge requests adds a check for this case.