### PR TITLE
Fix nil:NilClass error when queue['messages'] is nil.

### DIFF
--- a/bin/check-rabbitmq-messages.rb
+++ b/bin/check-rabbitmq-messages.rb
@@ -111,6 +111,7 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
       crit_queues = {}
       rabbitmq.queues.each do |queue|
         next if config[:excluded].include?(queue['name'])
+        queue['messages'] ||= 0
         if queue['messages'] >= config[:critical].to_i
           crit_queues["#{queue['name']}"] = queue['messages']
           next


### PR DESCRIPTION
This fixes a nil comparison error which occurs when queue['messages'] is nil. The error messages is as below.

```Check failed to run: undefined method `>=' for nil:NilClass, ["/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/check-rabbitmq-messages.rb:114:in `block in run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/check-rabbitmq-messages.rb:112:in `each'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-rabbitmq-0.0.4/bin/check-rabbitmq-messages.rb:112:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]```