### PR TITLE
Added the possibility to add a vhost filter for the drain time plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+- check-rabbitmq-queue-drain-time.rb: Added option to filter vhost with regular expression
+
 ## [1.0.0] - 2015-12-01
 ### Fixed
 - check-rabbitmq-node-health.rb: Fix messages for file descriptor alerts

--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -44,10 +44,9 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
          default: 15_672
 
   option :vhost,
-          description: 'Regular expression for filtering the RabbitMQ vhost',
-          short: '-v',
-          long: '--vhost VHOST',
-          default: false
+         description: 'Regular expression for filtering the RabbitMQ vhost',
+         short: '-v',
+         long: '--vhost VHOST'
 
   option :user,
          description: 'RabbitMQ management API user',
@@ -94,8 +93,8 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
       warning 'could not get rabbitmq queue info'
     end
 
-    if config[:vhost] != false
-      return rabbitmq_info.queues.select {|x| x['vhost'].match(config[:vhost])}
+    if config[:vhost]
+      return rabbitmq_info.queues.select { |x| x['vhost'].match(config[:vhost]) }
     end
 
     rabbitmq_info.queues

--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -43,6 +43,12 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 15_672
 
+  option :vhost,
+          description: 'Regular expression for filtering the RabbitMQ vhost',
+          short: '-v',
+          long: '--vhost VHOST',
+          default: false
+
   option :user,
          description: 'RabbitMQ management API user',
          long: '--user USER',
@@ -87,6 +93,11 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
     rescue
       warning 'could not get rabbitmq queue info'
     end
+
+    if config[:vhost] != false
+      return rabbitmq_info.queues.select {|x| x['vhost'].match(config[:vhost])}
+    end
+
     rabbitmq_info.queues
   end
 


### PR DESCRIPTION
In one of our projects we needed to check certain vhosts. This would be a patch to make it possible.