### PR TITLE
Support secure RabbitMQ installations

### DIFF
--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -72,7 +72,7 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
          default: nil
 
   option :no_verify_peer,
-         description: 'TLS Private Key to use when connecting',
+         description: 'Disable peer verification',
          long: '--no-verify-peer',
          boolean: true,
          default: true

--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -102,9 +102,9 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
 
     begin
       conn = Bunny.new("amqp#{ssl ? 's' : ''}://#{username}:#{password}@#{host}:#{port}/#{vhost}",
-              :tls_cert         => tls_cert,
-              :tls_key          => tls_key,
-              :verify_peer      => no_verify_peer)
+                       tls_cert:    tls_cert,
+                       tls_key:     tls_key,
+                       verify_peer: no_verify_peer)
       conn.start
       { 'status' => 'ok', 'message' => 'RabbitMQ server is alive' }
     rescue Bunny::PossibleAuthenticationFailureError

--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -61,6 +61,22 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :tls_cert,
+         description: 'TLS Certificate to use when connecting',
+         long: '--tls-cert CERT',
+         default: nil
+
+  option :tls_key,
+         description: 'TLS Private Key to use when connecting',
+         long: '--tls-key KEY',
+         default: nil
+
+  option :no_verify_peer,
+         description: 'TLS Private Key to use when connecting',
+         long: '--no-verify-peer',
+         boolean: true,
+         default: true
+
   def run
     res = vhost_alive?
 
@@ -74,15 +90,21 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
   end
 
   def vhost_alive?
-    host     = config[:host]
-    port     = config[:port]
-    username = config[:username]
-    password = config[:password]
-    vhost    = config[:vhost]
-    ssl      = config[:ssl]
+    host           = config[:host]
+    port           = config[:port]
+    username       = config[:username]
+    password       = config[:password]
+    vhost          = config[:vhost]
+    ssl            = config[:ssl]
+    tls_cert       = config[:tls_cert]
+    tls_key        = config[:tls_key]
+    no_verify_peer = config[:no_verify_peer]
 
     begin
-      conn = Bunny.new("amqp#{ssl ? 's' : ''}://#{username}:#{password}@#{host}:#{port}/#{vhost}")
+      conn = Bunny.new("amqp#{ssl ? 's' : ''}://#{username}:#{password}@#{host}:#{port}/#{vhost}",
+              :tls_cert         => tls_cert,
+              :tls_key          => tls_key,
+              :verify_peer      => no_verify_peer)
       conn.start
       { 'status' => 'ok', 'message' => 'RabbitMQ server is alive' }
     rescue Bunny::PossibleAuthenticationFailureError


### PR DESCRIPTION
The current `check-rabbitmq-alive.rb` script does not allow for checking secure RabbitMQ installations that have `verify` and `fail_if_no_peer_cert` enabled on the server. This PR adjusts the script to allow passing in certificates.

Since the default Sensu SSL certificate generation scripts use a common name of `sensu`, `verify_peer` on Bunny will fail as it uses the common name for additional verification. I could not see an easy way to pass in the common name to verify with Bunny, hence the reason for explicitly disabling `verify_peer` on the check.