### PR TITLE
Update metrics-rabbitmq-queue.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## Unreleased
 ### Added
 - check-rabbitmq-amqp-alive.rb: Added support for TLS authentication 
+- metrics-rabbitmq-queue.rb: Added option to filter vhost with regular expression
 
 ## [1.1.0] - 2015-12-30
 ### Added

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -43,6 +43,11 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
          proc: proc(&:to_i),
          default: 15_672
 
+  option :vhost,
+         description: 'Regular expression for filtering the RabbitMQ vhost',
+         short: '-v',
+         long: '--vhost VHOST'
+
   option :user,
          description: 'RabbitMQ management API user',
          long: '--user USER',
@@ -80,6 +85,11 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
     rescue
       warning 'could not get rabbitmq queue info'
     end
+    
+    if config[:vhost]
+      return rabbitmq_info.queues.select { |x| x['vhost'].match(config[:vhost]) }
+    end
+
     rabbitmq_info.queues
   end
 

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -85,7 +85,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
     rescue
       warning 'could not get rabbitmq queue info'
     end
-    
+
     if config[:vhost]
       return rabbitmq_info.queues.select { |x| x['vhost'].match(config[:vhost]) }
     end


### PR DESCRIPTION
Update to include vhost option as is available in check-rabbitmq-queue-drain-time.rb

Changed code has been lifted verbatim from the drain time check, which in turn was originally based upon this queue metrics plugin.