### PR TITLE
add option to ignore SSL errors on tests that use rest-client

### DIFF
--- a/bin/check-rabbitmq-alive.rb
+++ b/bin/check-rabbitmq-alive.rb
@@ -63,6 +63,12 @@ class CheckRabbitMQAlive < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :verify_ssl_off,
+         description: 'Do not check validity of SSL cert. Use for self-signed certs, etc (insecure)',
+         long: '--verify_ssl_off',
+         boolean: true,
+         default: false
+
   def run
     res = vhost_alive?
 
@@ -76,15 +82,16 @@ class CheckRabbitMQAlive < Sensu::Plugin::Check::CLI
   end
 
   def vhost_alive?
-    host     = config[:host]
-    port     = config[:port]
-    username = config[:username]
-    password = config[:password]
-    vhost    = config[:vhost]
-    ssl      = config[:ssl]
+    host       = config[:host]
+    port       = config[:port]
+    username   = config[:username]
+    password   = config[:password]
+    vhost      = config[:vhost]
+    ssl        = config[:ssl]
+    verify_ssl = config[:verify_ssl_off]
 
     begin
-      resource = RestClient::Resource.new "http#{ssl ? 's' : ''}://#{host}:#{port}/api/aliveness-test/#{vhost}", username, password
+      resource = RestClient::Resource.new "http#{ssl ? 's' : ''}://#{host}:#{port}/api/aliveness-test/#{vhost}", :user => username, :password => password, :verify_ssl => !verify_ssl
       # Attempt to parse response (just to trigger parse exception)
       _response = JSON.parse(resource.get) == { 'status' => 'ok' }
       { 'status' => 'ok', 'message' => 'RabbitMQ server is alive' }

--- a/bin/check-rabbitmq-alive.rb
+++ b/bin/check-rabbitmq-alive.rb
@@ -91,7 +91,12 @@ class CheckRabbitMQAlive < Sensu::Plugin::Check::CLI
     verify_ssl = config[:verify_ssl_off]
 
     begin
-      resource = RestClient::Resource.new "http#{ssl ? 's' : ''}://#{host}:#{port}/api/aliveness-test/#{vhost}", :user => username, :password => password, :verify_ssl => !verify_ssl
+      resource = RestClient::Resource.new(
+        "http#{ssl ? 's' : ''}://#{host}:#{port}/api/aliveness-test/#{vhost}",
+        user: username,
+        password: password,
+        verify_ssl: !verify_ssl
+      )
       # Attempt to parse response (just to trigger parse exception)
       _response = JSON.parse(resource.get) == { 'status' => 'ok' }
       { 'status' => 'ok', 'message' => 'RabbitMQ server is alive' }

--- a/bin/check-rabbitmq-cluster-health.rb
+++ b/bin/check-rabbitmq-cluster-health.rb
@@ -67,6 +67,12 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :verify_ssl_off,
+         description: 'Do not check validity of SSL cert. Use for self-signed certs, etc (insecure)',
+	 long: '--verify_ssl_off',
+         boolean: true,
+         default: false
+
   def run
     res = cluster_healthy?
 
@@ -95,16 +101,17 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
   end
 
   def cluster_healthy?
-    host     = config[:host]
-    port     = config[:port]
-    username = config[:username]
-    password = config[:password]
-    ssl      = config[:ssl]
-    nodes    = config[:nodes].split(',')
+    host       = config[:host]
+    port       = config[:port]
+    username   = config[:username]
+    password   = config[:password]
+    ssl        = config[:ssl]
+    verify_ssl = config[:verify_ssl_off]
+    nodes      = config[:nodes].split(',')
 
     begin
       ssl ? url_prefix = 'https' : url_prefix = 'http'
-      resource = RestClient::Resource.new "#{url_prefix}://#{host}:#{port}/api/nodes", username, password
+      resource = RestClient::Resource.new "#{url_prefix}://#{host}:#{port}/api/nodes", :user => username, :password => password, :verify_ssl => !verify_ssl
       # create a hash of the server names and their running state
       servers_status = Hash[JSON.parse(resource.get).map { |server| [server['name'], server['running']] }]
 

--- a/bin/check-rabbitmq-cluster-health.rb
+++ b/bin/check-rabbitmq-cluster-health.rb
@@ -69,7 +69,7 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
 
   option :verify_ssl_off,
          description: 'Do not check validity of SSL cert. Use for self-signed certs, etc (insecure)',
-	 long: '--verify_ssl_off',
+         long: '--verify_ssl_off',
          boolean: true,
          default: false
 
@@ -111,7 +111,12 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
 
     begin
       ssl ? url_prefix = 'https' : url_prefix = 'http'
-      resource = RestClient::Resource.new "#{url_prefix}://#{host}:#{port}/api/nodes", :user => username, :password => password, :verify_ssl => !verify_ssl
+      resource = RestClient::Resource.new(
+        "#{url_prefix}://#{host}:#{port}/api/nodes",
+        user: username,
+        password: password,
+        verify_ssl: !verify_ssl
+      )
       # create a hash of the server names and their running state
       servers_status = Hash[JSON.parse(resource.get).map { |server| [server['name'], server['running']] }]
 

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -61,6 +61,12 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :verify_ssl_off,
+         description: 'Do not check validity of SSL cert. Use for self-signed certs, etc (insecure)',
+         long: '--verify_ssl_off',
+         boolean: true,
+         default: false
+
   option :memwarn,
          description: 'Warning % of mem usage vs high watermark',
          short: '-m',
@@ -124,15 +130,16 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
   end
 
   def node_healthy?
-    host     = config[:host]
-    port     = config[:port]
-    username = config[:username]
-    password = config[:password]
-    ssl      = config[:ssl]
+    host       = config[:host]
+    port       = config[:port]
+    username   = config[:username]
+    password   = config[:password]
+    ssl        = config[:ssl]
+    verify_ssl = config[:verify_ssl_off]
 
     begin
       ssl ? url_prefix = 'https' : url_prefix = 'http'
-      resource = RestClient::Resource.new "#{url_prefix}://#{host}:#{port}/api/nodes", username, password
+      resource = RestClient::Resource.new "#{url_prefix}://#{host}:#{port}/api/nodes", :user => username, :password => password, :verify_ssl => !verify_ssl
       # Parse our json data
       nodeinfo = JSON.parse(resource.get)[0]
 

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -139,7 +139,12 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
 
     begin
       ssl ? url_prefix = 'https' : url_prefix = 'http'
-      resource = RestClient::Resource.new "#{url_prefix}://#{host}:#{port}/api/nodes", :user => username, :password => password, :verify_ssl => !verify_ssl
+      resource = RestClient::Resource.new(
+        "#{url_prefix}://#{host}:#{port}/api/nodes",
+        user: username,
+        password: password,
+        verify_ssl: !verify_ssl
+      )
       # Parse our json data
       nodeinfo = JSON.parse(resource.get)[0]
 


### PR DESCRIPTION
The three tests that use rest-client need a way to deal with self-signed rabbit certs like the other tests do (carrot-top ignores by default and the bunny-based tests have a flag similar to what I just added).  Especially useful since sensu itself provides a tool that makes you a self-signed cert for your rabbit setup.