### PR TITLE
fix default vhost

### DIFF
--- a/bin/check-rabbitmq-queue.rb
+++ b/bin/check-rabbitmq-queue.rb
@@ -42,7 +42,7 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
          description: 'RabbitMQ vhost',
          short: '-v',
          long: '--vhost VHOST',
-         default: '%2F'
+         default: ''
 
   option :ssl,
          description: 'Enable SSL for connection to the API',


### PR DESCRIPTION
using %2F as the default vhost results in a request to rabbit api of
`/api/queues/%2F` which returns 401.

```
./bin/check-rabbitmq-queue.rb \
  --password :::password:::
  --host sensu-rabbit
  --user sensu
  --queue results

Check failed to run: 401 "Unauthorized",
["/opt/boxen/rbenv/versions/2.0.0-p645/lib/ruby/2.0.0/net/http/response.rb:119:in `error!'", "/Users/fess/check/sensu-plugins-rabbitmq/vendor/bundle/ruby/2.0.0/gems/carrot-top-0.0.7/lib/carrot-top.rb:59:in `fetch_uri'", "/Users/fess/check/sensu-plugins-rabbitmq/vendor/bundle/ruby/2.0.0/gems/carrot-top-0.0.7/lib/carrot-top.rb:24:in `query_api'", "/Users/fess/check/sensu-plugins-rabbitmq/vendor/bundle/ruby/2.0.0/gems/carrot-top-0.0.7/lib/carrot-top.rb:28:in `method_missing'", "./bin/check-rabbitmq-queue.rb:106:in `run'", "/Users/fess/check/sensu-plugins-rabbitmq/vendor/bundle/ruby/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

```
%  curl -I http://sensu:password@sensu-rabbit:15672/api/queues/%2F
HTTP/1.1 401 Unauthorized
Server: MochiWeb/1.1 WebMachine/1.10.0 (never breaks eye contact)
Date: Tue, 23 Feb 2016 11:01:22 GMT
Content-Length: 80
```

note that if %2F was intended to be `/` `/` also works.  `%2F` doesn't.

```
%  curl -I http://sensu:password@sensu-rabbit:15672/api/queues//
HTTP/1.1 200 OK
Server: MochiWeb/1.1 WebMachine/1.10.0 (never breaks eye contact)
Date: Tue, 23 Feb 2016 11:02:27 GMT
Content-Type: application/json
Content-Length: 5860
Cache-Control: no-cache
```