### PR TITLE
add ssl_ca_file option to check-rabbitmq-cluster-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-rabbitmq-cluster-health.rb: Added option to provide SSL CA certificate
 
 ## [1.2.0] - 2016-04-13
 ### Added

--- a/bin/check-rabbitmq-cluster-health.rb
+++ b/bin/check-rabbitmq-cluster-health.rb
@@ -122,7 +122,7 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
         password: password,
         verify_ssl: !verify_ssl
       }
-      options.merge!(ssl_ca_file: ssl_ca_file) unless ssl_ca_file.empty?
+      options[:ssl_ca_file] = ssl_ca_file unless ssl_ca_file.empty?
 
       resource = RestClient::Resource.new(
         "#{url_prefix}://#{host}:#{port}/api/nodes",

--- a/bin/check-rabbitmq-cluster-health.rb
+++ b/bin/check-rabbitmq-cluster-health.rb
@@ -73,6 +73,11 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :ssl_ca_file,
+         description: 'Path to SSL CA .crt',
+         long: '--ssl_ca_file CA_PATH',
+         default: ''
+
   def run
     res = cluster_healthy?
 
@@ -101,21 +106,27 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
   end
 
   def cluster_healthy?
-    host       = config[:host]
-    port       = config[:port]
-    username   = config[:username]
-    password   = config[:password]
-    ssl        = config[:ssl]
-    verify_ssl = config[:verify_ssl_off]
-    nodes      = config[:nodes].split(',')
+    host        = config[:host]
+    port        = config[:port]
+    username    = config[:username]
+    password    = config[:password]
+    ssl         = config[:ssl]
+    verify_ssl  = config[:verify_ssl_off]
+    nodes       = config[:nodes].split(',')
+    ssl_ca_file = config[:ssl_ca_file]
 
     begin
       url_prefix = ssl ? 'https' : 'http'
-      resource = RestClient::Resource.new(
-        "#{url_prefix}://#{host}:#{port}/api/nodes",
+      options = {
         user: username,
         password: password,
         verify_ssl: !verify_ssl
+      }
+      options.merge!(ssl_ca_file: ssl_ca_file) unless ssl_ca_file.empty?
+
+      resource = RestClient::Resource.new(
+        "#{url_prefix}://#{host}:#{port}/api/nodes",
+        options
       )
       # create a hash of the server names and their running state
       servers_status = Hash[JSON.parse(resource.get).map { |server| [server['name'], server['running']] }]


### PR DESCRIPTION
If I use my own SSL CA, I want to provide the path to the ca-certificate to the RestClient call.

