### PR TITLE
add ssl_ca_file option to check-rabbitmq-cluster-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-rabbitmq-cluster-health.rb: Added option to provide SSL CA certificate
 
 ## [1.2.0] - 2016-04-13
 ### Added
-- check-rabbitmq-amqp-alive.rb: Added support for TLS authentication 
+- check-rabbitmq-amqp-alive.rb: Added support for TLS authentication
 - metrics-rabbitmq-queue.rb: Added option to filter vhost with regular expression
 - Added option to skip SSL cert checking
 


### PR DESCRIPTION
squashed https://github.com/sensu-plugins/sensu-plugins-rabbitmq/pull/30 into one commit

This adds an option to pass the path to a ssl_ca_file to the cluster health check