### PR TITLE
Fix for issue #31:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - check-rabbitmq-cluster-health.rb: Added option to provide SSL CA certificate
 
+## [1.2.1] - 2016-05-26
+### Added
+- check-rabbitmq-queue-drain-time.rb: Added default of ``false`` for ``filter`` option and now logically determine whether to filter or to use all found queues
+
 ## [1.2.0] - 2016-04-13
 ### Added
 - check-rabbitmq-amqp-alive.rb: Added support for TLS authentication

--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -60,7 +60,8 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
 
   option :filter,
          description: 'Regular expression for filtering queues',
-         long: '--filter REGEX'
+         long: '--filter REGEX',
+         default: false
 
   option :ssl,
          description: 'Enable SSL for connection to the API',
@@ -93,7 +94,11 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
       warning 'could not get rabbitmq queue info'
     end
 
-    queues = rabbitmq_info.queues.select { |q| q['name'].match(Regexp.new(config[:filter])) }
+    if config[:filter]
+      queues = rabbitmq_info.queues.select { |q| q['name'].match(Regexp.new(config[:filter])) }
+    else
+      queues = rabbitmq_info.queues.select { |q| q['name'] }
+    end
 
     if config[:vhost]
       return queues.select { |x| x['vhost'].match(config[:vhost]) }


### PR DESCRIPTION
Regarding issue https://github.com/sensu-plugins/sensu-plugins-rabbitmq/issues/31

Added a default of ``false`` for the filter option and an if/else
condition to only match and assign queues based on the filter regex if
one was supplied. If not it assumes all queues should be checked for
drain time.