### PR TITLE
[Issues 31] Add a catch all regex filter default for the queue drain check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+ - check-rabbitmq-queue-drain.rb: Added a default include-all value for the regex queue filter option
 
 ## [1.3.0] - 2016-04-13
 ### Added

--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -61,6 +61,7 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
   option :filter,
          description: 'Regular expression for filtering queues',
          long: '--filter REGEX'
+         default: '.*'
 
   option :ssl,
          description: 'Enable SSL for connection to the API',

--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -60,7 +60,7 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
 
   option :filter,
          description: 'Regular expression for filtering queues',
-         long: '--filter REGEX'
+         long: '--filter REGEX',
          default: '.*'
 
   option :ssl,


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, to include a sensible default value - https://github.com/sensu-plugins/sensu-plugins-rabbitmq/issues/31

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

- [x] Ready for review/merge

#### Purpose

Add a sensible default to the `check-rabbitmq-queue-drain.rb` check, for those who simply want to check all of their queues and monitor the drain times.

#### Known Compatablity Issues
None observed...

