### PR TITLE
fix incompatibility issue with sensu >= 0.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.4.0] - 2016-07-24
+### Changed
+- bump bunny version to 2.5.0
+- bump amq-protocol version to 2.0.1
+- drop ruby v1.9.3 support
+
 ## [1.3.0] - 2016-04-13
 ### Added
 - check-rabbitmq-cluster-health.rb: Added option to provide SSL CA certificate

--- a/Rakefile
+++ b/Rakefile
@@ -8,11 +8,7 @@ require 'yard/rake/yardoc_task'
 
 desc 'Don\'t run Rubocop for unsupported versions'
 begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
+  args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
 end
 
 YARD::Rake::YardocTask.new do |t|

--- a/lib/sensu-plugins-rabbitmq/version.rb
+++ b/lib/sensu-plugins-rabbitmq/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsRabbitMQ
   module Version
     MAJOR = 1
-    MINOR = 3
-    PATCH = 1
+    MINOR = 4
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'json',                      '~> 2.0.1'
 end

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -2,12 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-rabbitmq'
-else
-  require_relative 'lib/sensu-plugins-rabbitmq'
-end
+require_relative 'lib/sensu-plugins-rabbitmq'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
@@ -31,7 +26,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
 
   s.summary                = 'Sensu plugins for rabbitmq'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
@@ -41,8 +36,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'carrot-top',     '0.0.7'
   s.add_runtime_dependency 'stomp',          '1.3.4'
   s.add_runtime_dependency 'rest-client',    '1.8.0'
-  s.add_runtime_dependency 'bunny',          '1.7.0'
-  s.add_runtime_dependency 'amq-protocol',   '1.9.2' # locked as bunny 1.7.0 deps breaks on runby < 2
+  s.add_runtime_dependency 'bunny',          '2.5.0'
+  s.add_runtime_dependency 'amq-protocol',   '2.0.1'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
https://github.com/sensu-plugins/sensu-plugins-rabbitmq/issues/35
https://github.com/sensu-plugins/sensu-plugins-rabbitmq/issues/23

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Since sensu >= 0.24 updated to sensu-transport v6.0.0 which in turn requires amq-protocol v2.0.1, and the plugin requires amq-protocol v1.9.3 which isn't used anymore in sensu core, it's better to update amq-protocol, and bunny to latest versions which are used by sensu.

* bump bunny version to 2.5.0
* bump amq-protocol version to 2.0.1
* update CHANGELOG.md file with changes
* bump plugin version to 1.3.2

#### Known Compatibility Issues
* New plugin version is compatible with sensu >= 0.24 
* For sensu < 0.24 previous version of plugin works fine.
* Drop support of ruby v1.9.3 since latest amq-protocol, and bunny versions doesn't support ruby v1.9.3 anymore.