### PR TITLE
Fix/rabbitmq osx non numeric fd_used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [2.0.1] - 2016-10-31
+### Fixed
+- check-rabbitmq-node-health: prevent fd check failing on OSX due to non-numeric fd_used
+
 ## [2.0.0] - 2016-10-17
 ### Added
  - check-rabbitmq-queue-drain.rb: Added a default include-all value for the regex queue filter option

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -153,7 +153,9 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
       # Determine % sockets consumed
       psocket = format('%.2f', nodeinfo['sockets_used'].fdiv(nodeinfo['sockets_total']) * 100)
       # Determine % file descriptors consumed
-      pfd = format('%.2f', nodeinfo['fd_used'].fdiv(nodeinfo['fd_total']) * 100)
+      if nodeinfo['fd_used'].is_a?(Numeric)
+        pfd = format('%.2f', nodeinfo['fd_used'].fdiv(nodeinfo['fd_total']) * 100)
+      end
 
       # build status and message
       status = 'ok'

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -153,6 +153,7 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
       # Determine % sockets consumed
       psocket = format('%.2f', nodeinfo['sockets_used'].fdiv(nodeinfo['sockets_total']) * 100)
       # Determine % file descriptors consumed
+      # Non-numeric value fails silently to handle fd_used = 'unknown' on OSX
       if nodeinfo['fd_used'].is_a?(Numeric)
         pfd = format('%.2f', nodeinfo['fd_used'].fdiv(nodeinfo['fd_total']) * 100)
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, see https://github.com/sensu-plugins/sensu-plugins-rabbitmq/issues/47

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Fix plugin functionality on OSX where it fails when it encounter non-numeric 'unknown' fd_used value

#### Known Compatablity Issues

