### PR TITLE
Added features for using regex in queue name and pretty output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [2.0.2] - 2017-01-02
+### Added
+ - check-rabbitmq-queue.rb: Added features for using regex in queue name and pretty output
+
 ## [2.0.1] - 2016-10-31
 ### Fixed
 - check-rabbitmq-node-health: prevent fd check failing on OSX due to non-numeric fd_used


### PR DESCRIPTION
Hi guys,

I had a really important task to adopt this plugin for monitoring queues, specified using regex, as queues are being created and deleted automatically.
I would like to share with you my changes, maybe it will be useful for someone else.

Changes doesn't brake any functionality, only adding features.

New command line options:
- regex, Boolean, default: false. If you specify this option, your --queue option will be working as regex
- pretty, Boolean, default: false. If you specify this option, output will be multilines