### PR TITLE
Added --below feature and fixing bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+ - check-rabbitmq-queue.rb: Fixes for assigning values to critical or warning states (@alexpekurovsky)
 
 ## [2.1.0] - 2017-01-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+ - check-rabbitmq-queue.rb: Added --below feature to specify if value below threshold should generate alert (@alexpekurovsky) 
+
 ### Fixed
  - check-rabbitmq-queue.rb: Fixes for assigning values to critical or warning states (@alexpekurovsky)
 

--- a/bin/check-rabbitmq-queue.rb
+++ b/bin/check-rabbitmq-queue.rb
@@ -134,15 +134,23 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
         total = queue['messages']
         total = 0 if total.nil?
         message total.to_s
-        unless config[:below]
-          @crit << "#{queue['name']}:#{total}" if total >= config[:critical].to_i
-          @warn << "#{queue['name']}:#{total}" if total >= config[:warn].to_i && total < config[:critical].to_i
-        else
-          @crit << "#{queue['name']}:#{total}" if total <= config[:critical].to_i
-          @warn << "#{queue['name']}:#{total}" if total <= config[:warn].to_i && total > config[:critical].to_i
-        end
+        assign_alerts(queue['name'], total)
       end
     end
+    generate_output
+  end
+
+  def assign_alerts(queue_name, total)
+    if config[:below]
+      @crit << "#{queue_name}:#{total}" if total <= config[:critical].to_i
+      @warn << "#{queue_name}:#{total}" if total <= config[:warn].to_i && total > config[:critical].to_i
+    else
+      @crit << "#{queue_name}:#{total}" if total >= config[:critical].to_i
+      @warn << "#{queue_name}:#{total}" if total >= config[:warn].to_i && total < config[:critical].to_i
+    end
+  end
+
+  def generate_output
     if @crit.empty? && @warn.empty?
       ok
     elsif !@crit.empty?

--- a/bin/check-rabbitmq-queue.rb
+++ b/bin/check-rabbitmq-queue.rb
@@ -128,8 +128,8 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
         total = queue['messages']
         total = 0 if total.nil?
         message total.to_s
-        @crit << "#{queue['name']}:#{total}" if total > config[:critical].to_i
-        @warn << "#{queue['name']}:#{total}" if total > config[:warn].to_i && total < config[:critical].to_i
+        @crit << "#{queue['name']}:#{total}" if total >= config[:critical].to_i
+        @warn << "#{queue['name']}:#{total}" if total >= config[:warn].to_i && total < config[:critical].to_i
       end
     end
     if @crit.empty? && @warn.empty?


### PR DESCRIPTION
I found small bug in my previous pull request.
In case of messages inside queue equals warning or critical threshold, it wasn't going to appropriate alerts. Fixed.

Also added --below feature to generate alert in case of values below threshold.
For example, you need an alert when amount of messages in queue less than some number. Just specify --below option and set critical to be less than warning. E.g. Critical: 500, Warning: 1000.