### PR TITLE
Update stomp and sensu-plugin gems to remove Object::timeout deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
  - check-rabbitmq-queue.rb: Fixes for assigning values to critical or warning states (@alexpekurovsky)
 
+### Changed
+- bump stomp version to 1.4.3
+- bump sensu-plugin version to 1.4.4
+
 ## [2.1.0] - 2017-01-10
 ### Added
  - check-rabbitmq-queue.rb: Added features for using regex in queue name and pretty output (@alexpekurovsky)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Changed
 - bump stomp version to 1.4.3
-- bump sensu-plugin version to 1.4.4
 
 ## [2.1.0] - 2017-01-10
 ### Added

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -32,9 +32,9 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsRabbitMQ::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 1.4.4'
   s.add_runtime_dependency 'carrot-top',     '0.0.7'
-  s.add_runtime_dependency 'stomp',          '1.3.4'
+  s.add_runtime_dependency 'stomp',          '1.4.3'
   s.add_runtime_dependency 'rest-client',    '1.8.0'
   s.add_runtime_dependency 'bunny',          '2.5.0'
   s.add_runtime_dependency 'amq-protocol',   '2.0.1'

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsRabbitMQ::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '~> 1.4.4'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
   s.add_runtime_dependency 'carrot-top',     '0.0.7'
   s.add_runtime_dependency 'stomp',          '1.4.3'
   s.add_runtime_dependency 'rest-client',    '1.8.0'


### PR DESCRIPTION
Fixes the Object::timeout deprecation issue.