### PR TITLE
Minor fix check-rabbitmq-consumers

### DIFF
--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -121,7 +121,7 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
         next if config[:exclude].include?(queue['name'])
       end
       missing.delete(queue['name'])
-      consumers = queue['consumers']
+      consumers = queue['consumers'] || 0
       critical.push(queue['name']) if consumers <= config[:critical]
       warn.push(queue['name']) if consumers <= config[:warn]
     end


### PR DESCRIPTION
RabbitMQ sometimes return empty string for consumers variable and crash this Sensu check, this fix will replace empty value with 0.

Log:

> Check failed to run: undefined method `<=' for nil:NilClass, ["/etc/sensu/plugins/check-rabbitmq-consumers.rb:126:in `block in run'", "/etc/sensu/plugins/check-rabbitmq-consumers.rb:115:in `each'", "/etc/sensu/plugins/check-rabbitmq-consumers.rb:115:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.4.2/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
