### PR TITLE
Added rescue for network partition

### DIFF
--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -122,7 +122,7 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
           next if config[:exclude].include?(queue['name'])
         end
         missing.delete(queue['name'])
-        consumers = queue['consumers']
+        consumers = queue['consumers'] || 0
         critical.push(queue['name']) if consumers <= config[:critical]
         warn.push(queue['name']) if consumers <= config[:warn]
       end

--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -112,20 +112,23 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
     critical = []
     warn = []
 
-    rabbit.queues.each do |queue|
-      # if specific queues were passed only monitor those.
-      # if specific queues to exclude were passed then skip those
-      if config[:queue]
-        next unless config[:queue].include?(queue['name'])
-      elsif config[:exclude]
-        next if config[:exclude].include?(queue['name'])
+    begin
+      rabbit.queues.each do |queue|
+        # if specific queues were passed only monitor those.
+        # if specific queues to exclude were passed then skip those
+        if config[:queue]
+          next unless config[:queue].include?(queue['name'])
+        elsif config[:exclude]
+          next if config[:exclude].include?(queue['name'])
+        end
+        missing.delete(queue['name'])
+        consumers = queue['consumers']
+        critical.push(queue['name']) if consumers <= config[:critical]
+        warn.push(queue['name']) if consumers <= config[:warn]
       end
-      missing.delete(queue['name'])
-      consumers = queue['consumers']
-      critical.push(queue['name']) if consumers <= config[:critical]
-      warn.push(queue['name']) if consumers <= config[:warn]
+    rescue
+      critical 'Could not find any queue, check rabbitmq server'
     end
-
     return_condition(missing, critical, warn)
   end
 end


### PR DESCRIPTION
Currently when RabbitMQ cluster have network partition this plugin fail and report:

Check failed to run: undefined method `<' for nil:NilClass, ["/etc/sensu/plugins/check-rabbitmq-consumers.rb:131:in `block in run'", "/etc/sensu/plugins/check-rabbitmq-consumers.rb:121:in `each'", "/etc/sensu/plugins/check-rabbitmq-consumers.rb:121:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.2/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]

Now with this fix it will report:
CheckRabbitMQConsumers CRITICAL: Could not find any queue, check rabbitmq server

## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

