### PR TITLE
Remove extra slash causing RabbitMQ to return 404

### DIFF
--- a/bin/check-rabbitmq-queue.rb
+++ b/bin/check-rabbitmq-queue.rb
@@ -121,7 +121,7 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
     @crit = []
     @warn = []
     rabbitmq = acquire_rabbitmq_info
-    queues = rabbitmq.method_missing('/queues/' + config[:vhost])
+    queues = rabbitmq.method_missing('queues/' + config[:vhost])
     config[:queue].each do |q|
       unless (queues.map { |hash| hash['name'] }.include?(q) && config[:regex] == false) || config[:regex] == true
         unless config[:ignore]


### PR DESCRIPTION
RabbitMQ 3.6.6 seems to ignore the extra slash but sometime in 3.6.7 to 3.6.9 it returns a 404 instead.

## Pull Request Checklist

In reference to #57 

#### General

- [] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [] Update README with any necessary configuration snippets


#### Purpose

#### Known Compatablity Issues

