### PR TITLE
Metrics regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+ - metrics-rabbitmq-queue.rb: --metrics option to specifiy which metrics to gather
+
 ## [3.0.0] - 2017-05-10
 ### Breaking change
  - Previously some checks used --user to specify username, now all scripts use --username

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -144,7 +144,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
       metrics.each do |metric|
         next unless metric.match(config[:metrics])
         value = queue.dig(*metric.split('.'))
-        # Special case of *gress rates for backward-compatibility
+        # Special case of ingress and egress rates for backward-compatibility
         if metric =~ 'backing_queue_status.avg'
           value = format('%.4f', value)
           metric = metric.split('.')[-1]


### PR DESCRIPTION
Implements issue #61: Add option to specify which metrics to gather.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

The option `--metrics` can be used to tell which metrics to output. It is a regex telling which metric names to match. The name of each metric is the dotted path of the metric in the dictionary returned by carrot_top. There is also the extra metric `drain_time`, computed by the plugin.

Each value is output with the name `$scheme.$queue.$metric`, where $metric is the full path. The exception to that is for e/ingress rates, for backward-compatibility. Also, though in my opinion the consumer of the value should decide what precision they want, the value of e/ingress rates is reformatted to `%.4f`, again for backward compatibility.

#### Known Compatibility Issues

