### PR TITLE
Fix use of =~ operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+ - metrics-rabbitmq-queue.rb: Fix use of =~ operator
+
 ## [3.1.0] - 2017-05-16
 ### Added
  - metrics-rabbitmq-queue.rb: --metrics option to specifiy which metrics to gather (@rthouvenin)

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -145,7 +145,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
         next unless metric.match(config[:metrics])
         value = queue.dig(*metric.split('.'))
         # Special case of ingress and egress rates for backward-compatibility
-        if metric =~ 'backing_queue_status.avg'
+        if metric =~ /backing_queue_status.avg/
           value = format('%.4f', value)
           metric = metric.split('.')[-1]
         end


### PR DESCRIPTION
Amends PR #62, to fix a mistake in the use of `=~` operator.
