### PR TITLE
Allow querying specific node for check-rabbitmq-node-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Proper node definition support for node health check (@Infraded)
+- check-rabbitmq-node-health: Proper node definition support (@Infraded)
 - ruby 2.4 support (@majormoses)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
+- Proper node definition support for node health check (@Infraded)
 - ruby 2.4 support (@majormoses)
 
 ### Fixed

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -152,12 +152,12 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
   end
 
   def node_healthy?
-    host       = config[:host]
-    port       = config[:port]
-    username   = config[:username]
-    password   = config[:password]
-    ssl        = config[:ssl]
-    verify_ssl = config[:verify_ssl_off]
+    host        = config[:host]
+    port        = config[:port]
+    username    = config[:username]
+    password    = config[:password]
+    ssl         = config[:ssl]
+    verify_ssl  = config[:verify_ssl_off]
     node_prefix = config[:node_prefix]
 
     # Determine node hostname to query, as this may not be the same as connection hostname

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 #  encoding: UTF-8
+
 #
 # RabbitMQ check node health plugin
 # ===
@@ -161,16 +162,16 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
     node_prefix = config[:node_prefix]
 
     # Determine node hostname to query, as this may not be the same as connection hostname
-    if config[:node_host]
-      # Statically set by config
-      node_host = config[:node_host]
-    elsif config[:node_use_fqdn]
-      # Resolved from system running check, full FQDN, the same as RABBITMQ_USE_LONGNAME
-      node_host = Socket.gethostname
-    else
-      # Default of short hostname, resolved from system
-      node_host = Socket.gethostname.partition('.').first
-    end
+    node_host = if config[:node_host]
+                  # Statically set by config
+                  config[:node_host]
+                elsif config[:node_use_fqdn]
+                  # Resolved from system running check, full FQDN, the same as RABBITMQ_USE_LONGNAME
+                  Socket.gethostname
+                else
+                  # Default of short hostname, resolved from system
+                  Socket.gethostname.partition('.').first
+                end
 
     if config[:ini]
       ini = IniFile.load(config[:ini])


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes, fixes #43

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Existing check only looks at the first node in the node list. This leaves node health unknown for all other nodes in a cluster. This update allows the check to determine the running system's node name (using defaults matching RMQ), or allows it to be specified in the check definition.

#### Known Compatibility Issues