### PR TITLE
Added queue selection by regex to consumers check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
+- check-rabbitmq-consumers.rb: Added ability to select queues with regular expressions. (@jtduby)
+
+### Added
 - ruby 2.4 support (@majormoses)
 
 ### Fixed

--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #  encoding: UTF-8
-#
+
 # Check RabbitMQ consumers
 # ===
 #
@@ -130,11 +130,11 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
 
   def run
     # create arrays to hold failures
-    if config[:regex]
-      missing = []
-    else
-      missing = config[:queue] || []
-    end
+    missing = if config[:regex]
+                []
+              else
+                config[:queue] || []
+              end
     critical = []
     warn = []
 
@@ -144,12 +144,10 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
         # if specific queues to exclude were passed then skip those
         if config[:regex]
           next unless queue['name'] =~ /#{config[:queue].first}/
-        else
-          if config[:queue]
-            next unless config[:queue].include?(queue['name'])
-          elsif config[:exclude]
-            next if config[:exclude].include?(queue['name'])
-          end
+        elsif config[:queue]
+          next unless config[:queue].include?(queue['name'])
+        elsif config[:exclude]
+          next if config[:exclude].include?(queue['name'])
         end
         missing.delete(queue['name'])
         consumers = queue['consumers'] || 0


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** 
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
When new queues are added, we needed the ability to mass select (or exclude) them without further intervention on our part. So, I implemented a --regex flag that treats anything put in --queue as a regular expression. The upside of this is by using a not in the regex, one can select all queues but those with a specific term in them.

Example: the following incantation does a consumer check on all queues but those with 'foo' or 'bar' in their names.

`check-rabbitmq-consumers.rb --user <user> --password <pass> --warn 10 --critical 5 --regex --queue '^(?!.*foo|.*bar).*'`

#### Known Compatibility Issues
None