### PR TITLE
Added heartbeat and threading options to check-rabbitmq-amqp-alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### check-rabbitmq-amqp-alive.rb: Added threading and heartbeat interval options (@bdeo)
+
 ### Added
 - ruby 2.4 support (@majormoses)
 

--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -78,6 +78,18 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
          boolean: true,
          default: true
 
+  option :heartbeat,
+         description: 'Client heartbeat interval',
+         long: '--heartbeat HB',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :threaded,
+         description: 'Enables threaded connections',
+         long: '--threaded THREAD',
+         boolean: true,
+         default: true
+
   option :ini,
          description: 'Configuration ini file',
          short: '-i',
@@ -103,6 +115,9 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
     tls_cert       = config[:tls_cert]
     tls_key        = config[:tls_key]
     no_verify_peer = config[:no_verify_peer]
+    heartbeat      = config[:heartbeat]
+    threaded       = config[:threaded]
+
     if config[:ini]
       ini = IniFile.load(config[:ini])
       section = ini['auth']
@@ -117,7 +132,9 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
       conn = Bunny.new("amqp#{ssl ? 's' : ''}://#{username}:#{password}@#{host}:#{port}/#{vhost}",
                        tls_cert:    tls_cert,
                        tls_key:     tls_key,
-                       verify_peer: no_verify_peer)
+                       verify_peer: no_verify_peer,
+                       heartbeat:   heartbeat,
+                       threaded:    threaded)
       conn.start
       conn.close if conn.connected?
       { 'status' => 'ok', 'message' => 'RabbitMQ server is alive' }


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [X] RuboCop passes

- [X] Existing tests pass

#### Purpose
This adds the ability to set the heartbeat interval on the Bunny client as well as threaded. This becomes desirable when the rabbit server has heartbeats disabled and causes race conditions on connection open and subsequent close.
#### Known Compatibility Issues
None. Default options on new arguments are the defaults for rubyBunny.