### PR TITLE
Adds check-rabbitmq-queues-synchronised.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+- check-rabbitmq-queues-synchronised.rb: added new check if all mirrored queues are synchronised (@cyrilgdn)
+
+
 ## [3.5.0] - 2017-09-05
 ### Changed
 - RabbitMQ module with common code (@rthouvenin)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
  * bin/check-rabbitmq-node-usage.rb
  * bin/check-rabbitmq-queue-drain-time.rb
  * bin/check-rabbitmq-queue.rb
+ * bin/check-rabbitmq-queues-synchronised.rb
  * bin/check-rabbitmq-stomp-alive.rb
  * bin/metrics-rabbitmq-overview.rb
  * bin/metrics-rabbitmq-queue.rb

--- a/bin/check-rabbitmq-queues-synchronised.rb
+++ b/bin/check-rabbitmq-queues-synchronised.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+#  encoding: UTF-8
+#
+# Check RabbitMQ Queues Synchronised
+# ===
+#
+# DESCRIPTION:
+# This plugin checks that all mirrored queues which have slaves are synchronised.
+#
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# LICENSE:
+# Copyright 2017 Cyril Gaudin <cyril.gaudin@gmail.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rest_client'
+require 'sensu-plugins-rabbitmq'
+
+# main plugin class
+class CheckRabbitMQQueuesSynchronised < Sensu::Plugin::RabbitMQ::Check
+  option :list_queues,
+         description: 'If set, will ouput the list of all unsynchronised queues, otherwise only the count',
+         long: '--list-queues',
+         boolean: true,
+         default: false
+
+  def run
+    @crits = []
+
+    queues = get_queues config
+
+    queues.each do |q|
+      next unless q.key?('slave_nodes')
+
+      nb_slaves = q['slave_nodes'].count
+      next if nb_slaves.zero?
+      unsynchronised = nb_slaves - q['synchronised_slave_nodes'].count
+      if unsynchronised != 0
+        @crits << "#{q['name']}: #{unsynchronised} unsynchronised slave(s)"
+      end
+    end
+    if @crits.empty?
+      ok
+    elsif config[:list_queues]
+      critical @crits.join(' - ')
+    else
+      critical "#{@crits.count} unsynchronised queue(s)"
+    end
+  rescue Errno::ECONNREFUSED => e
+    critical e.message
+  rescue => e
+    unknown e.message
+  end
+
+  def get_queues(config)
+    url_prefix = config[:ssl] ? 'https' : 'http'
+    options = {
+      user: config[:username],
+      password: config[:password]
+    }
+
+    resource = RestClient::Resource.new(
+      "#{url_prefix}://#{config[:host]}:#{config[:port]}/api/queues",
+      options
+    )
+    JSON.parse(resource.get)
+  end
+end

--- a/test/check-rabbitmq-queues-synchronised_spec.rb
+++ b/test/check-rabbitmq-queues-synchronised_spec.rb
@@ -1,0 +1,243 @@
+#!/usr/bin/env ruby
+#
+# check-rabbitmq-queues-synchronised_spec
+#
+# DESCRIPTION:
+#   Tests for check-rabbitmq-queues-synchronised.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   bundle exec rake spec
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2017 Cyril Gaudin <cyril.gaudin@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+
+require_relative './spec_helper.rb'
+require_relative '../bin/check-rabbitmq-queues-synchronised.rb'
+
+json_ok = '[
+    {
+        "name": "test_queue1",
+        "node": "rabbit@node1",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node2"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [
+            "rabbit@node2"
+        ],
+        "vhost": "/"
+    },
+    {
+        "name": "test_queue2",
+        "node": "rabbit@node2",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node1"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [
+            "rabbit@node1"
+        ],
+        "vhost": "/"
+    }
+]'
+
+json_nok1 = '[
+    {
+        "name": "test_queue1",
+        "node": "rabbit@node1",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node2"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [],
+        "vhost": "/"
+    },
+    {
+        "name": "test_queue2",
+        "node": "rabbit@node2",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node1"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [
+            "rabbit@node1"
+        ],
+        "vhost": "/"
+    }
+]'
+
+json_nok2 = '[
+    {
+        "name": "test_queue1",
+        "node": "rabbit@node1",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node2"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [],
+        "vhost": "/"
+    },
+    {
+        "name": "test_queue2",
+        "node": "rabbit@node2",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node1"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [],
+        "vhost": "/"
+    }
+]'
+
+json_nok3 = '[
+    {
+        "name": "test_queue1",
+        "node": "rabbit@node1",
+        "policy": "HA",
+        "slave_nodes": [
+            "rabbit@node2",
+            "rabbit@node3",
+            "rabbit@node4"
+        ],
+        "state": "running",
+        "synchronised_slave_nodes": [
+            "rabbit@node2"
+        ],
+        "vhost": "/"
+    }
+]'
+
+json_ok_not_mirrored = '[
+    {
+        "name": "test_queue1",
+        "node": "rabbit@node1",
+        "policy": "HA",
+        "state": "running",
+        "vhost": "/"
+    }
+]'
+
+json_no_queue = '[]'
+
+bad_json = '{}{}'
+
+describe CheckRabbitMQQueuesSynchronised, 'run' do
+  let(:check) do
+    CheckRabbitMQQueuesSynchronised.new
+  end
+
+  let(:listCheck) do
+    CheckRabbitMQQueuesSynchronised.new ['--list-queues']
+  end
+
+  it 'should be ok with synchronised queues' do
+    resource = double
+    allow(resource).to receive(:get) { json_ok }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).not_to receive(:critical)
+    expect(check).not_to receive(:unknown)
+    expect(check).to receive(:ok)
+
+    check.run
+  end
+
+  it 'should be critical with one unsynchronised queue' do
+    resource = double
+    allow(resource).to receive(:get) { json_nok1 }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).not_to receive(:ok)
+    expect(check).not_to receive(:unknown)
+    expect(check).to receive(:critical).with('1 unsynchronised queue(s)')
+
+    check.run
+
+    expect(listCheck).not_to receive(:ok)
+    expect(listCheck).not_to receive(:unknown)
+    expect(listCheck).to receive(:critical).with('test_queue1: 1 unsynchronised slave(s)')
+
+    listCheck.run
+  end
+
+  it 'should be critical with a partially unsynchronised queues' do
+    resource = double
+    allow(resource).to receive(:get) { json_nok2 }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).not_to receive(:ok)
+    expect(check).not_to receive(:unknown)
+    expect(check).to receive(:critical).with('2 unsynchronised queue(s)')
+
+    check.run
+
+    expect(listCheck).not_to receive(:ok)
+    expect(listCheck).not_to receive(:unknown)
+    expect(listCheck).to receive(:critical).with('test_queue1: 1 unsynchronised slave(s) - test_queue2: 1 unsynchronised slave(s)')
+
+    listCheck.run
+  end
+
+  it 'should be critical with two unsynchronised queues' do
+    resource = double
+    allow(resource).to receive(:get) { json_nok3 }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).not_to receive(:ok)
+    expect(check).not_to receive(:unknown)
+    expect(check).to receive(:critical).with('1 unsynchronised queue(s)')
+
+    check.run
+
+    expect(listCheck).not_to receive(:ok)
+    expect(listCheck).not_to receive(:unknown)
+    expect(listCheck).to receive(:critical).with('test_queue1: 2 unsynchronised slave(s)')
+
+    listCheck.run
+  end
+
+  it 'should be ok with not mirrored queues' do
+    resource = double
+    allow(resource).to receive(:get) { json_ok_not_mirrored }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).to receive(:ok)
+    expect(check).not_to receive(:unknown)
+    expect(check).not_to receive(:critical)
+
+    check.run
+  end
+
+  it 'should be ok without queue' do
+    resource = double
+    allow(resource).to receive(:get) { json_no_queue }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).to receive(:ok)
+    expect(check).not_to receive(:unknown)
+    expect(check).not_to receive(:critical)
+
+    check.run
+  end
+
+  it 'should be unknown with bad json' do
+    resource = double
+    allow(resource).to receive(:get) { bad_json }
+    allow(RestClient::Resource).to receive(:new) { resource }
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:unknown)
+    expect(check).not_to receive(:critical)
+
+    check.run
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

This check will verify that all mirrored queues are synchronised.

#### Examples
```

$ bin/check-rabbitmq-queues-synchronised.rb -h rabbitmq.service.consul --username guest --password guest              
CheckRabbitMQQueuesSynchronised OK

# With an unsynchronised queue
$ bin/check-rabbitmq-queues-synchronised.rb -h rabbitmq.service.consul --username guest --password guest
CheckRabbitMQQueuesSynchronised CRITICAL: 1 unsynchronised queues

$ bin/check-rabbitmq-queues-synchronised.rb -h rabbitmq.service.consul --username guest --password guest --list-queues
CheckRabbitMQQueuesSynchronised CRITICAL: test_queue: 1 unsynchronised slave(s)
```