### PR TITLE
Add documentation on minimum rabbitmq permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,23 @@
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
+## Permissions
+
+In order to run these checks you need the following permissions set:
+```
+:conf => '^aliveness-test$',
+:write => '^amq\.default$',
+:read => '.*'
+```
+You must also add the `monitoring` tag.
+
+This can be done like this:
+```
+rabbitmqctl add_user sensu_monitoring $MY_SUPER_LONG_SECURE_PASSWORD
+rabbitmqctl set_permissions  -p / sensu_monitoring "^aliveness-test$" "^amq\.default$" "^(amq\.default|aliveness-test)$"
+rabbitmqctl set_user_tags sensu_monitoring monitoring
+```
+
+**It is highly recommended that you do not give administrator access! and use minimum permissions!**
+
 ## Notes


### PR DESCRIPTION
I can't say this is an exsaustive list but this is what I use at work and I can confirm it works for:
- `check-rabbitmq-alive.rb`
- `check-rabbitmq-cluster-health.rb`
- `check-rabbitmq-network-partitions.rb`
- `check-rabbitmq-node-health.rb`

Other checks and metrics scripts may require more permissions and can be added later if we find need for more permissions.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

closes #59 

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Add documentation on minimum permissions and warn people to not use a user with administrative purposes for monitoring rabbitmq from sensu.
#### Known Compatibility Issues
none