### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,12 @@ RegexpLiteral:
 
 Style/Documentation:
   Enabled: false
+
+# .match?() was added in ruby 2.4
+Performance/RegexpMatch:
+  Enabled: false
+
+## slow testing is oK
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -28,7 +27,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
 ## [3.6.0] - 2017-10-04
 ### Added
 - check-rabbitmq-queues-synchronised.rb: added new check if all mirrored queues are synchronised (@cyrilgdn)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-rabbitmq.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'
@@ -7,9 +9,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +37,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/check-rabbitmq-alive.rb
+++ b/bin/check-rabbitmq-alive.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ check alive plugin
 # ===
@@ -115,7 +116,7 @@ class CheckRabbitMQAlive < Sensu::Plugin::Check::CLI
       { 'status' => 'ok', 'message' => 'RabbitMQ server is alive' }
     rescue Errno::ECONNREFUSED => e
       { 'status' => 'critical', 'message' => e.message }
-    rescue => e
+    rescue StandardError => e
       { 'status' => 'unknown', 'message' => e.message }
     end
   end

--- a/bin/check-rabbitmq-amqp-alive.rb
+++ b/bin/check-rabbitmq-amqp-alive.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ check amqp alive plugin
 # ===
@@ -142,7 +143,7 @@ class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
       { 'status' => 'critical', 'message' => 'Possible authentication failure' }
     rescue Bunny::TCPConnectionFailed
       { 'status' => 'critical', 'message' => 'TCP connection refused' }
-    rescue => e
+    rescue StandardError => e
       { 'status' => 'unknown', 'message' => e.message }
     end
   end

--- a/bin/check-rabbitmq-cluster-health.rb
+++ b/bin/check-rabbitmq-cluster-health.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ check cluster nodes health plugin
 # ===
@@ -161,7 +162,7 @@ class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
       { 'status' => status, 'message' => message }
     rescue Errno::ECONNREFUSED => e
       { 'status' => 'critical', 'message' => e.message }
-    rescue => e
+    rescue StandardError => e
       { 'status' => 'unknown', 'message' => e.message }
     end
   end

--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
 
 # Check RabbitMQ consumers
 # ===
@@ -109,19 +109,19 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
         password: password,
         ssl: config[:ssl]
       )
-    rescue
+    rescue StandardError
       warning 'could not connect to rabbitmq'
     end
     connection
   end
 
   def return_condition(missing, critical, warning)
-    if critical.count > 0 || missing.count > 0
+    if critical.count.positive? || missing.count.positive?
       message = ''
-      message << "Queues in critical state: #{critical.join(', ')}. " if critical.count > 0
-      message << "Queues missing: #{missing.join(', ')}" if missing.count > 0
+      message << "Queues in critical state: #{critical.join(', ')}. " if critical.count.positive?
+      message << "Queues missing: #{missing.join(', ')}" if missing.count.positive?
       critical(message)
-    elsif warning.count > 0
+    elsif warning.count.positive?
       warning("Queues in warning state: #{warning.join(', ')}")
     else
       ok
@@ -154,7 +154,7 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
         critical.push(queue['name']) if consumers <= config[:critical]
         warn.push(queue['name']) if consumers <= config[:warn]
       end
-    rescue
+    rescue StandardError
       critical 'Could not find any queue, check rabbitmq server'
     end
     return_condition(missing, critical, warn)

--- a/bin/check-rabbitmq-messages.rb
+++ b/bin/check-rabbitmq-messages.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # Check RabbitMQ Messages
 # ===
@@ -112,7 +113,7 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
         password: password,
         ssl: config[:ssl]
       )
-    rescue
+    rescue StandardError
       warning 'Could not connect to rabbitmq'
     end
     rabbitmq_info

--- a/bin/check-rabbitmq-network-partitions.rb
+++ b/bin/check-rabbitmq-network-partitions.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ Network Partitions Check
 # ===
@@ -68,7 +69,7 @@ class CheckRabbitMQPartitions < Sensu::Plugin::Check::CLI
     ok 'no network partition detected'
   rescue Errno::ECONNREFUSED => e
     critical e.message
-  rescue => e
+  rescue StandardError => e
     unknown e.message
   end
 

--- a/bin/check-rabbitmq-node-health.rb
+++ b/bin/check-rabbitmq-node-health.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ check node health plugin
 # ===
@@ -215,7 +216,7 @@ class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
       { 'status' => status, 'message' => message }
     rescue Errno::ECONNREFUSED => e
       { 'status' => 'critical', 'message' => e.message }
-    rescue => e
+    rescue StandardError => e
       { 'status' => 'unknown', 'message' => e.message }
     end
   end

--- a/bin/check-rabbitmq-node-usage.rb
+++ b/bin/check-rabbitmq-node-usage.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby -W0
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ check node health plugin
 # ===
@@ -72,7 +73,7 @@ class CheckRabbitMQNodeUsage < Sensu::Plugin::Check::CLI
          description: 'Resource type',
          required: true,
          long: '--type TYPE',
-         in: %w(mem socket fd proc disk)
+         in: %w[mem socket fd proc disk]
 
   option :memwarn,
          description: 'Warning % of mem usage vs high watermark',
@@ -179,7 +180,7 @@ class CheckRabbitMQNodeUsage < Sensu::Plugin::Check::CLI
     end
 
     { 'status' => output[:status], 'message' => output[:message] }
-  rescue => e
+  rescue StandardError => e
     { 'status' => 'unknown', 'message' => e.message }
   end
 

--- a/bin/check-rabbitmq-queue-drain-time.rb
+++ b/bin/check-rabbitmq-queue-drain-time.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ Queue Drain Time
 # ===
@@ -106,7 +107,7 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
         password: password,
         ssl: config[:ssl]
       )
-    rescue
+    rescue StandardError
       warning 'could not get rabbitmq queue info'
     end
 
@@ -125,10 +126,10 @@ class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
 
     acquire_rabbitmq_queues.each do |queue|
       # we don't care about empty queues and they'll have an infinite drain time so skip them
-      next if queue['messages'] == 0 || queue['messages'].nil?
+      next if queue['messages'].zero? || queue['messages'].nil?
 
       # handle rate of zero which is an infinite time until empty
-      if queue['backing_queue_status']['avg_egress_rate'].to_f == 0
+      if queue['backing_queue_status']['avg_egress_rate'].to_f.zero?
         crit_queues[queue['name']] = 'Infinite (drain rate = 0)'
         next
       end

--- a/bin/check-rabbitmq-queue.rb
+++ b/bin/check-rabbitmq-queue.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: false
+
 #
 # Check RabbitMQ Queue Messages
 # ===
@@ -22,13 +23,16 @@
 # for details.
 
 require 'sensu-plugins-rabbitmq'
+require 'sensu-plugins-rabbitmq/check'
+require 'sensu-plugin/check/cli'
 
 # main plugin class
-class CheckRabbitMQMessages < Sensu::Plugin::RabbitMQ::Check
+class CheckRabbitMQQueue < Sensu::Plugin::RabbitMQ::Check
   option :queue,
          description: 'RabbitMQ queue to monitor',
          long: '--queue queue_names',
          required: true,
+         # not sure if there is a better way to handle frozen strings
          proc: proc { |a| a.split(',') }
 
   option :warn,

--- a/bin/check-rabbitmq-queues-synchronised.rb
+++ b/bin/check-rabbitmq-queues-synchronised.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # Check RabbitMQ Queues Synchronised
 # ===
@@ -55,7 +56,7 @@ class CheckRabbitMQQueuesSynchronised < Sensu::Plugin::RabbitMQ::Check
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message
-  rescue => e
+  rescue StandardError => e
     unknown e.message
   end
 

--- a/bin/check-rabbitmq-stomp-alive.rb
+++ b/bin/check-rabbitmq-stomp-alive.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ check alive plugin
 # ===
@@ -118,7 +119,7 @@ class CheckRabbitStomp < Sensu::Plugin::Check::CLI
       { 'status' => 'critical', 'message' => 'TCP connection refused' }
     rescue Stomp::Error::BrokerException => e
       { 'status' => 'critical', 'message' => "Error from broker. Check auth details? #{e.message}" }
-    rescue => e
+    rescue StandardError => e
       { 'status' => 'unknown', 'message' => "#{e.class}: #{e.message}" }
     end
   end

--- a/bin/metrics-rabbitmq-exchange.rb
+++ b/bin/metrics-rabbitmq-exchange.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ Exchange Metrics
 # ===

--- a/bin/metrics-rabbitmq-overview.rb
+++ b/bin/metrics-rabbitmq-overview.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ Overview Metrics
 # ===
@@ -99,7 +100,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
         password: password,
         ssl: config[:ssl]
       )
-    rescue
+    rescue StandardError
       warning 'could not get rabbitmq info'
     end
     rabbitmq_info

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # RabbitMQ Queue Metrics
 # ===

--- a/lib/sensu-plugins-rabbitmq.rb
+++ b/lib/sensu-plugins-rabbitmq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ruby_dig'
 
 require 'sensu-plugins-rabbitmq/version'

--- a/lib/sensu-plugins-rabbitmq/check.rb
+++ b/lib/sensu-plugins-rabbitmq/check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'sensu-plugin/check/cli'
 require 'sensu-plugins-rabbitmq/rabbitmq'
 

--- a/lib/sensu-plugins-rabbitmq/metrics.rb
+++ b/lib/sensu-plugins-rabbitmq/metrics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sensu-plugin/metric/cli'
 require 'socket'
 require 'sensu-plugins-rabbitmq/rabbitmq'

--- a/lib/sensu-plugins-rabbitmq/rabbitmq.rb
+++ b/lib/sensu-plugins-rabbitmq/rabbitmq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'carrot-top'
 require 'inifile'
 
@@ -66,7 +68,7 @@ module Sensu
               password: password,
               ssl: config[:ssl]
             )
-          rescue
+          rescue StandardError
             warning 'could not get rabbitmq info'
           end
 

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 require 'sensu-plugins-rabbitmq/version'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
 
   s.date                   = Date.today.to_s
@@ -14,7 +16,7 @@ Gem::Specification.new do |s|
                               via `rabbitmq_management`, and more'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-rabbitmq'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -26,20 +28,21 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
 
   s.summary                = 'Sensu plugins for rabbitmq'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsRabbitMQ::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
-  s.add_runtime_dependency 'carrot-top',     '0.0.7'
-  s.add_runtime_dependency 'stomp',          '1.4.3'
-  s.add_runtime_dependency 'rest-client',    '1.8.0'
-  s.add_runtime_dependency 'bunny',          '2.5.0'
+
   s.add_runtime_dependency 'amq-protocol',   '2.0.1'
+  s.add_runtime_dependency 'bunny',          '2.5.0'
+  s.add_runtime_dependency 'carrot-top',     '0.0.7'
   s.add_runtime_dependency 'inifile',        '3.0.0'
+  s.add_runtime_dependency 'rest-client',    '1.8.0'
   s.add_runtime_dependency 'ruby_dig',       '0.0.2'
+  s.add_runtime_dependency 'stomp',          '1.4.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -47,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/test/check-rabbitmq-queue_spec.rb
+++ b/test/check-rabbitmq-queue_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # check-rabbitmq-queue_spec
 #
@@ -41,9 +43,9 @@ end
 class RabbitInfoStub
 end
 
-describe CheckRabbitMQMessages, 'run' do
+describe CheckRabbitMQQueue, 'run' do
   let(:check) do
-    CheckRabbitMQMessages.new ['--queue', 'q1,q2']
+    CheckRabbitMQQueue.new ['--queue', 'q1,q2']
   end
 
   it 'should return a warning when the queue does not exist' do

--- a/test/check-rabbitmq-queues-synchronised_spec.rb
+++ b/test/check-rabbitmq-queues-synchronised_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # check-rabbitmq-queues-synchronised_spec
 #

--- a/test/metrics-rabbitmq-exchange_spec.rb
+++ b/test/metrics-rabbitmq-exchange_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # metrics-rabbitmq-exchange_spec
 #

--- a/test/metrics-rabbitmq-queue_spec.rb
+++ b/test/metrics-rabbitmq-queue_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # metrics-rabbitmq-queue_spec
 #

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
 
 RSpec.configure do |c|


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc:
- appeased the cops

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Address CVE, see parent issue for details
#### Known Compatibility Issues
removes ruby `< 2.1` support