### PR TITLE
Add option to skip cert verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+## [4.0.2] - 2018-03-30
+### Changed
+- check-rabbitmq-queues-synchronised.rb: Allow skipping of ssl cert verification, similar to other checks (@mattdoller)
+
 ## [4.0.1] - 2018-03-27
 ### Security
 - updated yard dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 (@majormoses)

--- a/bin/check-rabbitmq-queues-synchronised.rb
+++ b/bin/check-rabbitmq-queues-synchronised.rb
@@ -32,6 +32,12 @@ class CheckRabbitMQQueuesSynchronised < Sensu::Plugin::RabbitMQ::Check
          boolean: true,
          default: false
 
+  option :verify_ssl_off,
+         description: 'Do not check validity of SSL cert. Use for self-signed certs, etc (insecure)',
+         long: '--verify_ssl_off',
+         boolean: true,
+         default: false
+
   def run
     @crits = []
 
@@ -64,7 +70,8 @@ class CheckRabbitMQQueuesSynchronised < Sensu::Plugin::RabbitMQ::Check
     url_prefix = config[:ssl] ? 'https' : 'http'
     options = {
       user: config[:username],
-      password: config[:password]
+      password: config[:password],
+      verify_ssl: !config[:verify_ssl_off]
     }
 
     resource = RestClient::Resource.new(

--- a/test/check-rabbitmq-queues-synchronised_spec.rb
+++ b/test/check-rabbitmq-queues-synchronised_spec.rb
@@ -242,4 +242,33 @@ describe CheckRabbitMQQueuesSynchronised, 'run' do
 
     check.run
   end
+
+  it 'should set the verify_ssl param to true by default' do
+    resource = double
+
+    allow(resource).to receive(:get) { json_ok }
+    allow(RestClient::Resource).to receive(:new) do |_, options|
+      expect(options[:verify_ssl]).to eql(true)
+      resource
+    end
+
+    expect(check).to receive(:ok)
+
+    check.run
+  end
+
+  it 'allows overriding the verify_ssl param' do
+    check = CheckRabbitMQQueuesSynchronised.new ['--verify_ssl_off']
+    resource = double
+
+    allow(resource).to receive(:get) { json_ok }
+    allow(RestClient::Resource).to receive(:new) do |_, options|
+      expect(options[:verify_ssl]).to eql(false)
+      resource
+    end
+
+    expect(check).to receive(:ok)
+
+    check.run
+  end
 end


### PR DESCRIPTION
Similar to other checks that offer the same option, this update
allows for skipping ssl cert verification when specified.
