### PR TITLE
Compute queues metrics for damaged queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- metrics-rabbitmq-queue.rb: fix metrics collection under corrupted RabbitMQ cluster circumstances (@multani)
 
 ## [4.1.0] - 2018-03-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
-### Changed
+### Fixed
 - metrics-rabbitmq-queue.rb: fix metrics collection under corrupted RabbitMQ cluster circumstances (@multani)
 
 ## [4.1.0] - 2018-03-31

--- a/bin/metrics-rabbitmq-queue.rb
+++ b/bin/metrics-rabbitmq-queue.rb
@@ -51,7 +51,11 @@ class RabbitMQQueueMetrics < Sensu::Plugin::RabbitMQ::Metrics
 
       # calculate and output time till the queue is drained in drain metrics
       queue['messages'] ||= 0
-      drain_time = queue['messages'] / queue['backing_queue_status']['avg_egress_rate']
+      drain_time = if queue['backing_queue_status']
+                     queue['messages'] / queue['backing_queue_status']['avg_egress_rate']
+                   else
+                     0.0 / 0.0 # NaN
+                   end
       drain_time = 0 if drain_time.nan? || drain_time.infinite? # 0 rate with 0 messages is 0 time to drain
       queue['drain_time'] = drain_time.to_i
 


### PR DESCRIPTION
We have some queues which have been registered on a node which is not
present on our RabbitMQ cluster anymore.
The queue is still returned when contacting the /queues API endpoint but
most information are missing:

```
  {
    "message_stats"=>
    {
      "publish_details"=>
      {
        "rate"=>0.4
      },
      "publish"=>5816
    },
    "node"=>"rabbit@i-xxxxxxxxxxxxxxxxx.node.consul",
    "arguments"=>{},
    "exclusive"=>false,
    "auto_delete"=>true,
    "durable"=>false,
    "vhost"=>"/",
    "name"=>"i-yyyyyyyyyyyyyyyyy-1.2.0-1522722830",
    "messages"=>0
  }
```

Currently, the `metrics-rabbitmq-queue` facing this kind of queue fails
with:

```
  Check failed to run: undefined method `[]' for nil:NilClass, [
    "bin/metrics-rabbitmq-queue.rb:54:in `block in run'",
    "bin/metrics-rabbitmq-queue.rb:47:in `each'",
    "bin/metrics-rabbitmq-queue.rb:47:in `run'",
    "/home/multani/local/gems/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"
  ]
```

and doesn't return any metrics data anymore.

This patch handles such kind of queue and continue the processing of the
rest of the queues as usual.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass