### PR TITLE
Bump sensu-plugin version in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Breaking Changes
+- bump sensu-plugin version in dependencies to ~> 2.0.  This should fix the issue where multiple versions of json (1.8.6 and 2.0.2) are being loaded, causing checks to fail (@mattdoller)
 
 ## [4.1.1] - 2018-04-03
 ### Fixed

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsRabbitMQ::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 2.0'
 
   s.add_runtime_dependency 'amq-protocol',   '2.0.1'
   s.add_runtime_dependency 'bunny',          '2.5.0'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** 

no

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

This should solve a similar issue described [here](https://github.com/sensu-plugins/sensu-plugins-graphite/issues/61), where two versions of json (1.8.6 and 2.0.2) were being loaded.
