### PR TITLE
Added visual code coverage for testing using simplecov

### DIFF
--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -52,5 +52,8 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'rubocop',                   '~> 0.51.0'
+  s.add_development_dependency 'simplecov',                 '~> 0.16.1'
+  s.add_development_dependency 'simplecov-console',         '~> 0.4.2'
+  s.add_development_dependency 'simplecov-html',            '~> 0.10.2'
   s.add_development_dependency 'yard',                      '~> 0.9.11'
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'codeclimate-test-reporter'
+require 'simplecov'
+require 'simplecov-console'
 
 RSpec.configure do |c|
   # Sensu plugins run in the context of an at_exit handler. This prevents
@@ -28,4 +30,16 @@ CodeClimate::TestReporter.start
 
 def timestamp
   kind_of Numeric
+end
+
+SimpleCov.minimum_coverage 80
+SimpleCov.refuse_coverage_drop
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console
+  ]
+)
+SimpleCov.start do
+  add_filter '/test/'
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
SimpleCov (https://github.com/colszowka/simplecov) is a ruby code coverage tool useful for testing locally and as part of a CI/CD pipeline. It also integrates with codeclimate nicely but it will need configuring using the .travis file and a test token found in the project on codeclimate.

```
env:
  global:
    - CC_TEST_REPORTER_ID=<Add Your Test Coverage Token from CodeClimate here>
before_script:
  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
  - chmod +x ./cc-test-reporter
  - ./cc-test-reporter before-build

after_script:
  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
```


#### Known Compatibility Issues
