### PR TITLE
Add .dup to message string

### DIFF
--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -117,7 +117,7 @@ class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
 
   def return_condition(missing, critical, warning)
     if critical.count.positive? || missing.count.positive?
-      message = ''
+      message = ''.dup
       message << "Queues in critical state: #{critical.join(', ')}. " if critical.count.positive?
       message << "Queues missing: #{missing.join(', ')}" if missing.count.positive?
       critical(message)


### PR DESCRIPTION
Makes a mutable copy of the message string so that it can be altered when frozen_string_literal is true.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
