### PR TITLE
Backport changes from consumer-utilisation to consumers including tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- check-rabbitmq-consumers.rb: Backport recommended code updates. Add consumer count to warn/critical message. (@monkey670)
 
 ## [5.1.0] - 2018-05-15
 ### Added

--- a/bin/check-rabbitmq-consumer-utilisation.rb
+++ b/bin/check-rabbitmq-consumer-utilisation.rb
@@ -61,12 +61,6 @@ class CheckRabbitMQConsumerUtilisation < Sensu::Plugin::RabbitMQ::Check
          proc: proc(&:to_f),
          default: 0.5
 
-  def queue_list_builder(input)
-    return [] if input.nil?
-    return [input] if config[:regex]
-    input.split(',')
-  end
-
   def return_condition(missing, critical, warning)
     if critical.count > 0 || missing.count > 0
       message = []

--- a/bin/check-rabbitmq-consumers.rb
+++ b/bin/check-rabbitmq-consumers.rb
@@ -56,12 +56,6 @@ class CheckRabbitMQConsumers < Sensu::Plugin::RabbitMQ::Check
          proc: proc(&:to_i),
          default: 2
 
-  def queue_list_builder(input)
-    return [] if input.nil?
-    return [input] if config[:regex]
-    input.split(',')
-  end
-
   def return_condition(missing, critical, warning)
     if critical.count > 0 || missing.count > 0
       message = []

--- a/lib/sensu-plugins-rabbitmq/rabbitmq.rb
+++ b/lib/sensu-plugins-rabbitmq/rabbitmq.rb
@@ -83,6 +83,12 @@ module Sensu
           result_info
         end
 
+        def queue_list_builder(input)
+          return [] if input.nil?
+          return [input] if config[:regex]
+          input.split(',')
+        end
+
         def self.included(receiver)
           receiver.extend(Sensu::Plugin::RabbitMQ::Options)
           receiver.add_common_options

--- a/test/check-rabbitmq-consumers_spec.rb
+++ b/test/check-rabbitmq-consumers_spec.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: false
+
+#
+# check-rabbitmq-consumers_spec
+#
+# DESCRIPTION:
+#   Tests for check-rabbitmq-consumers.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#
+# LICENSE:
+# Copyright 2018 Mike Murray <37150283+monkey670@users.noreply.github.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require_relative './spec_helper.rb'
+require_relative '../bin/check-rabbitmq-consumers.rb'
+
+def consumer1
+  {
+    'name' => 'example-queue1',
+    'consumers' => 6
+  }
+end
+
+def consumer2
+  {
+    'name' => 'example-queue2',
+    'consumers' => 1
+  }
+end
+
+def consumer3
+  {
+    'name' => 'example3',
+    'consumers' => 4
+  }
+end
+
+def consumer4
+  {
+    'name' => 'example-queue4',
+    'consumers' => 1
+  }
+end
+
+def consumer5
+  {
+    'name' => 'example5',
+    'consumers' => 1
+  }
+end
+
+def consumer6
+  {
+    'name' => 'test-queue6',
+    'consumers' => 1
+  }
+end
+
+def consumer7
+  {
+    'name' => 'example-queue7',
+    'consumers' => 0
+  }
+end
+
+def consumer8
+  {
+    'name' => 'example-queue8',
+    'consumers' => 3
+  }
+end
+
+class RabbitInfoStub
+end
+
+describe CheckRabbitMQConsumers, 'run' do
+  it 'Threshold `ok` when the consumer is above the default threshold of 5' do
+    check = CheckRabbitMQConsumers.new ['--queue', 'example-queue1']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer1]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:critical)
+    expect(check).not_to receive(:warning)
+    expect(check).to receive(:ok)
+
+    check.run
+  end
+
+  it 'Threshold `critical` when the consumer is below the default threshold of 2' do
+    check = CheckRabbitMQConsumers.new []
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer2]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue2:1-Consumers. ')
+
+    check.run
+  end
+
+  it 'Threshold `warning` when the consumer is below the default threshold of 5' do
+    check = CheckRabbitMQConsumers.new []
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer3]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:warning).with('Queues in warning state: example3:4-Consumers')
+
+    check.run
+  end
+
+  it 'Threshold `critical` when the consumer is below the custom threshold of 0' do
+    check = CheckRabbitMQConsumers.new ['-c', '0']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer7]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue7:0-Consumers. ')
+
+    check.run
+  end
+
+  it 'Threshold `warning` when the consumer is below the custom threshold of 3' do
+    check = CheckRabbitMQConsumers.new ['-w', '3']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer8]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:warning).with('Queues in warning state: example-queue8:3-Consumers')
+
+    check.run
+  end
+
+  it 'Combined Threshold when the consumer is below the custom threshold of 3' do
+    check = CheckRabbitMQConsumers.new ['-c', '1', '-w', '3', '--queue', 'example*', '--exclude', 'example-queue2|test*', '--regex']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer1, consumer2, consumer3, consumer4, consumer5, consumer6, consumer7, consumer8]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue4:1-Consumers, example5:1-Consumers, example-queue7:0-Consumers. ')
+
+    check.run
+  end
+
+  it 'Regex should return all queues starting with example' do
+    check = CheckRabbitMQConsumers.new ['--regex', '--queue', 'example*']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer2, consumer4, consumer5, consumer6]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue2:1-Consumers, example-queue4:1-Consumers, example5:1-Consumers. ')
+
+    check.run
+  end
+
+  it 'Regex with exclude. Only example-queue2 and example-queue4 should be checked example5 and test-queue6 should be ignored' do
+    check = CheckRabbitMQConsumers.new ['--regex', '--queue', 'example*', '--exclude', 'example5']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer2, consumer4, consumer5, consumer6]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue2:1-Consumers, example-queue4:1-Consumers. ')
+
+    check.run
+  end
+
+  it 'Multi regex & exclude. Only example-queue4, example5 and test-queue6 should be checked example-queue2 should be ignored' do
+    check = CheckRabbitMQConsumers.new ['--regex', '--queue', 'example*|test*', '--exclude', 'example-queue2']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer2, consumer4, consumer5, consumer6]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue4:1-Consumers, example5:1-Consumers, test-queue6:1-Consumers. ')
+
+    check.run
+  end
+
+  it 'Exclude only. Only example-queue2, example-queue4 and example5 should be checked. test-queue6 should be ignored' do
+    check = CheckRabbitMQConsumers.new ['--exclude', 'test-queue6']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer2, consumer4, consumer5, consumer6]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues in critical state: example-queue2:1-Consumers, example-queue4:1-Consumers, example5:1-Consumers. ')
+
+    check.run
+  end
+
+  it 'Multi queue. A combination of queues with one missing' do
+    check = CheckRabbitMQConsumers.new ['--queue', 'nonexistant,example-queue1,example-queue2,test-queue6']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer1, consumer2, consumer3, consumer4, consumer6]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with("Queues in critical state: example-queue2:1-Consumers, test-queue6:1-Consumers. \nQueues missing: nonexistant")
+
+    check.run
+  end
+
+  it 'Unknown queue. The specified queue does not exist should return a critical' do
+    check = CheckRabbitMQConsumers.new ['--queue', 'nonexistant']
+    info_stub = RabbitInfoStub.new
+    allow(info_stub).to receive(:method_missing).and_return [consumer1, consumer2, consumer3, consumer4]
+    allow(check).to receive(:acquire_rabbitmq_info).and_return info_stub
+
+    expect(check).not_to receive(:ok)
+    expect(check).to receive(:critical).with('Queues missing: nonexistant')
+
+    check.run
+  end
+
+  it 'No queues recieved from rabbitmq api should return critical' do
+    check = CheckRabbitMQConsumers.new
+    expect { check.run }.to raise_error(SystemExit)
+      .and output("CheckRabbitMQConsumers CRITICAL: Could not find any queue, check rabbitmq server\n")
+      .to_stdout
+  end
+end

--- a/test/rabbitmq_spec.rb
+++ b/test/rabbitmq_spec.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: false
+
+#
+# rabbitmq
+#
+# DESCRIPTION:
+#   Tests for rabbitmq.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#
+# LICENSE:
+# Copyright 2018 Mike Murray <37150283+monkey670@users.noreply.github.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require_relative './spec_helper.rb'
+require_relative '../lib/sensu-plugins-rabbitmq/rabbitmq.rb'
+
+def queue_test
+  {
+    'name' => 'example-queue1'
+  }
+end
+
+class DummyClass
+end
+
+describe Sensu::Plugin::RabbitMQ do
+  before(:each) do
+    @options = {
+      host: 'localhost',
+      port: 55_672,
+      username: 'guest',
+      password: 'guest'
+    }
+    @dummy_class = DummyClass.new
+    @dummy_class.extend(Sensu::Plugin::RabbitMQ::Common)
+  end
+
+  it 'Acquire Rabbitmq info resuce' do
+    allow(@dummy_class).to receive(:warning)
+  end
+
+  it 'Acquire Rabbitmq info no config' do
+    allow(@dummy_class).to receive(:config).and_return(nil)
+    allow(@dummy_class).to receive(:warning) do |arg|
+      expect(arg).to eq('could not get rabbitmq info')
+    end
+  end
+
+  it 'Queue List Builder nil should return an empty array' do
+    allow(@dummy_class).to receive(:config).and_return('regex' => 'true')
+    check = @dummy_class.queue_list_builder nil
+    expect(check).to eq []
+  end
+
+  it 'Queue List Builder Regex should return a single array element' do
+    allow(@dummy_class).to receive(:config).and_return('regex' => 'true')
+    check = @dummy_class.queue_list_builder '.*'
+    expect(check).to eq ['.*']
+  end
+
+  it 'Queue List Builder String should return a single array element' do
+    allow(@dummy_class).to receive(:config).and_return('regex' => 'false')
+    check = @dummy_class.queue_list_builder 'example-queue1'
+    expect(check).to eq ['example-queue1']
+  end
+
+  it 'Queue List Builder String List should return array' do
+    allow(@dummy_class).to receive(:config).and_return('regex' => 'false')
+    check = @dummy_class.queue_list_builder 'example-queue1,example-queue2,example-queue3'
+    expect(check).to eq ['example-queue1', 'example-queue2', 'example-queue3']
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** Contains a fix for frozen string error which occurs when raising critical errors i.e. when the queue does not exist. This can be resolved by switching to a message array instead of a string. 

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [X] Tests

- [ ] Add the plugin to the README

- [X] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
This PR ports back the updated changes and removal of duplicate code completed under the consumer_utilisation PR.  This should be a non breaking change but includes an additional string in the message output for critical and warning. It now contains the count of consumers. Test cases have been included.

#### Known Compatibility Issues
