### PR TITLE
metrics-overview: export "total objects" (consumers, connections, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Changed
+- metrics-rabbitmq-overview.rb: add total objects metrics (channels, connections, consumers, etc.). (@multani)
+
 ## [5.2.0] - 2018-05-16
 ### Changed
 - check-rabbitmq-consumers.rb: Backport recommended code updates. Add consumer count to warn/critical message. (@monkey670)

--- a/bin/metrics-rabbitmq-overview.rb
+++ b/bin/metrics-rabbitmq-overview.rb
@@ -21,7 +21,12 @@
 #    host.rabbitmq.message_stats.deliver_no_ack.count  6661111 1344186404
 #    host.rabbitmq.message_stats.deliver_no_ack.rate 24.6867565643405  1344186404
 #    host.rabbitmq.message_stats.deliver_get.count 6661111 1344186404
-#    host.rabbitmq.message_stats.deliver_get.rate  24.6867565643405  1344186404#
+#    host.rabbitmq.message_stats.deliver_get.rate  24.6867565643405  1344186404
+#    host.rabbitmq.object_totals.channels.count 138 1344186404
+#    host.rabbitmq.object_totals.connections.count 88 1344186404
+#    host.rabbitmq.object_totals.consumers.count 127 1344186404
+#    host.rabbitmq.object_totals.exchanges.count 184 1344186404
+#    host.rabbitmq.object_totals.queues.count 90 1344186404
 #
 # PLATFORMS:
 #   Linux, BSD, Solaris
@@ -154,6 +159,15 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
         output "#{config[:scheme]}.message_stats.deliver_get.rate", overview['message_stats']['deliver_get_details']['rate'], timestamp
       end
     end
+
+    if overview.key?('object_totals') && !overview['object_totals'].empty?
+      %w[channels connections consumers exchanges queues].each do |key|
+        if overview['object_totals'].include?(key)
+          output "#{config[:scheme]}.object_totals.#{key}.count", overview['object_totals'][key], timestamp
+        end
+      end
+    end
+
     ok
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

This adds counts of global objects related to the cluster, such as number of total connections, total channels, total consumers, etc.

#### Known Compatibility Issues

This exports 5 new metrics of an already existing metrics plugin.