### PR TITLE
Update rest-client to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- bump version of rest-client to 2.0.2.  This should fix the issue where multiple versions of that gem would be loaded when running the rabbitmq plugin alongside the sensu http plugin. (@mattdoller)
 
 ## [5.4.0] - 2018-06-21
 ### Changed

--- a/sensu-plugins-rabbitmq.gemspec
+++ b/sensu-plugins-rabbitmq.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'bunny',          '2.5.0'
   s.add_runtime_dependency 'carrot-top',     '0.0.7'
   s.add_runtime_dependency 'inifile',        '3.0.0'
-  s.add_runtime_dependency 'rest-client',    '1.8.0'
+  s.add_runtime_dependency 'rest-client',    '2.0.2'
   s.add_runtime_dependency 'ruby_dig',       '0.0.2'
   s.add_runtime_dependency 'stomp',          '1.4.3'
 


### PR DESCRIPTION
The sensu-plugins-http gem also requires version 2.0.2 of rest-client,
and having both the http and rabbitmq sensu plugins causes conflicts
where both rest-client gems are loaded.  rest-client also recommends
upgrading from 1.x, and states that usage is largely compatible.

## Pull Request Checklist

**Is this in reference to an existing issue?**
no, but I can open one if it helps bookkeeping

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Fixes issue where multiple versions of the `rest-client` gem are loaded when the rabbitmq plugin is run alongside the http plugin.

#### Known Compatibility Issues
